### PR TITLE
Update from 1.14 to 1.15

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-python:
-  - 3.7 # [not (osx and arm64)]
-  - 3.8

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 python:
-  - 3.7
+  - 3.7 # [not (osx and arm64)]
   - 3.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
       build:
         - {{ compiler('c') }}                # [not win]
         - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('xorg-x11-util-macros') }}  # [linux and not aarch64]
+        - {{ cdt('xorg-x11-util-macros') }}  # [linux]
         - {{ cdt('libx11-devel') }}          # [linux]
         - {{ cdt('libxau-devel') }}          # [linux]
         - m2-autoconf                        # [win]
@@ -63,7 +63,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}                # [not win]
-        - {{ cdt('xorg-x11-util-macros') }}  # [linux and not aarch64]
+        - {{ cdt('xorg-x11-util-macros') }}  # [linux]
         - m2-autoconf                        # [win]
         - m2-automake{{ am_version }}        # [win]
         - m2-libtool                         # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
       build:
         - {{ compiler('c') }}                # [not win]
         - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-        - {{ cdt('xorg-x11-util-macros') }}  # [linux]
+        - {{ cdt('xorg-x11-util-macros') }}  # [linux and not aarch64]
         - {{ cdt('libx11-devel') }}          # [linux]
         - {{ cdt('libxau-devel') }}          # [linux]
         - m2-autoconf                        # [win]
@@ -63,7 +63,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}                # [not win]
-        - {{ cdt('xorg-x11-util-macros') }}  # [linux]
+        - {{ cdt('xorg-x11-util-macros') }}  # [linux and not aarch64]
         - m2-autoconf                        # [win]
         - m2-automake{{ am_version }}        # [win]
         - m2-libtool                         # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ outputs:
         #  Excellent: only new symbols
         #   https://abi-laboratory.pro/tracker/timeline/libxcb/
         - {{ pin_subpackage('libxcb') }}
+      missing_dso_whitelist:                 # [linux]
+        - $RPATH/libc.so.6                   # [linux]
     requirements:
       build:
         - {{ compiler('c') }}                # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,4 @@
-{% set xorg_name = "libxcb" %}
-{% set xorg_category = "xcb" %}
-{% set name = "libxcb" %}
-{% set version = "1.14" %}
-{% set libxcb_sha256 = "a55ed6db98d43469801262d81dc2572ed124edc3db31059d4e9916eb9f844c34" %}
-{% set xorg_proto_name = "xcb-proto" %}
-{% set proto_sha256 = "186a3ceb26f9b4a015f5a44dcc814c93033a5fc39684f36f1ecc79834416a605" %}
+{% set version = "1.15" %}
 {% set am_version = "1.15" %} # keep synchronized with build.sh
 
 package:
@@ -12,13 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.xz
-    sha256: {{ libxcb_sha256 }}
+  - url: https://xcb.freedesktop.org/dist/libxcb-{{ version }}.tar.gz
+    sha256: 1cb65df8543a69ec0555ac696123ee386321dfac1964a3da39976c9a05ad724d
     patches:
       - windows.patch  # [win]
       - 0001-Re-introduce-_xcb_lock_io-for-SLES11.patch
-  - url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_proto_name }}-{{ version }}.tar.xz
-    sha256: {{ proto_sha256 }}
+  - url: https://xcb.freedesktop.org/dist/xcb-proto-{{ version }}.tar.xz
+    sha256: d34c3b264e8365d16fa9db49179cfa3e9952baaf9275badda0f413966b65955f
     folder: proto
     patches:
       - windows-pythondir.patch  # [win]
@@ -88,10 +82,12 @@ outputs:
       summary: "Provides the XML-XCB protocol descriptions that libxcb uses to generate the majority of its code and API"
 
 about:
-  home: http://xcb.freedesktop.org/
+  home: https://xcb.freedesktop.org/
   license: MIT
   license_family: MIT
   license_file: COPYING
+  dev_url: https://gitlab.freedesktop.org/xorg/lib/libxcb
+  doc_url: https://xcb.freedesktop.org/XcbApi/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Home: https://xcb.freedesktop.org/
Repo: https://gitlab.freedesktop.org/xorg/lib/libxcb
License: https://gitlab.freedesktop.org/xorg/lib/libxcb/-/blob/libxcb-1.15/COPYING

No major change in build files from 1.14 to 1.15:
https://gitlab.freedesktop.org/xorg/lib/libxcb/-/compare/libxcb-1.14...libxcb-1.15?from_project_id=2429

Actions:
- Updated about section (dev_url, doc_url, home)
- Simplified source section
- Small fix for osx skipping
- Add $RPATH/libc.so.6 to missing_dso_whitelist
- Upload missing cdt packages: org-x11-util-macros-amzn2-aarch64
